### PR TITLE
Get all folders

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,4 +14,17 @@ app.get('/', (request, response) => {
   response.send('Welcome to the Palette Picker API');
 });
 
+app.get('/api/v1/users/:id/folders', async (request, response) => {
+  const { id } = request.params
+
+  try {
+    const folders = await database('folders')
+      .where('id', id)
+      .select();
+    response.status(200).json(folders)
+  } catch(error) {
+    response.status(500).json({error})
+  }
+
+})
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -19,9 +19,15 @@ app.get('/api/v1/users/:id/folders', async (request, response) => {
 
   try {
     const folders = await database('folders')
-      .where('id', id)
+      .where('user_id', id)
       .select();
-    response.status(200).json(folders)
+
+    if (!folders.length) {
+      return response.status(404)
+        .json({error: `No folders found for user ${id}`})
+    } else {
+      response.status(200).json(folders)
+    }
   } catch(error) {
     response.status(500).json({error})
   }

--- a/app.test.js
+++ b/app.test.js
@@ -20,17 +20,30 @@ describe('App', () => {
 
   describe('GET /api/v1/users/:id/folders', async () => {
     it('should return a 200 status and all folders', async () => {
-      const userId = 40
+      const user = await database('users').first();
+      const { id } = user
+
       const expectedFolders = await database('folders')
-        .where('id', userId)
+        .where('user_id', id)
         .select();
 
-      const response = await request(app).get(`/api/v1/users/${userId}/folders`);
+      const response = await request(app)
+        .get(`/api/v1/users/${id}/folders`);
 
       const folders = response.body
 
       expect(response.status).toBe(200);
       expect(folders).toEqual(expectedFolders)
+    })
+
+    it('should return a 404 status if it can not find matching folders', async ()=> {
+      const invalidId = -10;
+
+      const response = await request(app)
+        .get(`/api/v1/users/${invalidId}/folders`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`No folders found for user ${invalidId}`)
     })
   })
 })

--- a/app.test.js
+++ b/app.test.js
@@ -17,4 +17,20 @@ describe('App', () => {
       expect(res.status).toBe(200)
     });
   })
+
+  describe('GET /api/v1/users/:id/folders', async () => {
+    it('should return a 200 status and all folders', async () => {
+      const userId = 40
+      const expectedFolders = await database('folders')
+        .where('id', userId)
+        .select();
+
+      const response = await request(app).get(`/api/v1/users/${userId}/folders`);
+
+      const folders = response.body
+
+      expect(response.status).toBe(200);
+      expect(folders).toEqual(expectedFolders)
+    })
+  })
 })


### PR DESCRIPTION
#### What's this PR do?
- This PR adds the tests (happy/sad) for the GET /api/v1/users/:id/folders enpoint, and add the endpoint as well.
#### Where should the reviewer start?
 - Dip into the app.test file to see both tests, check the endpoints in App
#### How should this be manually tested?
- Run npm test
#### Any background context you want to provide?
- Encountered an issue in which the id of the first user in our user's table would have a different id each time the tests were run, but then I remembered `database('users').first();`
#### What are the relevant tickets?
- resolves #10 