### PR TITLE
Delete palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ BackEnd Repo for Palette Picker
 
 | API Paths             | Request       | Response                   |
 | --------------------  |:-------------:| ------------------------------------------------:|
+<<<<<<< HEAD
 | 'api/v1/folders'| **GET**       |  **An Array of Folder Objects**  EX: ```[ { id: 577, folder_name: 'Project #1', user_id: 193 },{...}, {...} ]```|        |
 | 'api/v1/folders/:folderId'| **GET**   |   **A single folder (object)** *Ex:* ```{"id": 1,"folder_name": "Join the Fold", "user_id": 1}```|
 | 'api/v1/folders/:folderId/palettes| **GET** | **An Array of palletes for single folder** *EX:* ```[ { id: 4771, palette_name: 'Palette #1', color_one: '#80adaa', color_two: '#d9c9fb', color_three: '#9c5f3d', color_four: '#4ba9b3', color_five: '#a6617c', folder_id: 1591 }, { ... }, { ... } ] ``` |
 | 'api/v1/folders/:folderId/palettes/:paletteId'| **GET**| **A single palette (object)** Ex: ```{"id": 1, "palette_name": "Palette #1", "color_one": "#80adaa", "color_two": "#d9c9fb", "color_three": "#9c5f3d", "color_four": "#4ba9b3", "color_five": "#a6617c", "folder_id": 1}```|
 | 'api/v1/folders'| **POST**  *Must include folder_name(string) in body of request object Ex:* ```{folder_name:'Palettes to Save the World'}```|id of posted folder: ```{id: <integer}```|
+| 'api/v1/folders/:folderId/palettes'          | **POST** *Must include paletteName(string) and colors(Array of strings) in body of request object Ex:* ```{paletteName: 'Big Ole Palette', colors: ["#80adaa", "#d9c9fb", "#9c5f3d", "#4ba9b3", "#a6617c"]}```| **An object with newly created palette, folderId, and its paletteId Ex:**```{paletteName: 'Big Ole Palette', colors: ["#80adaa", "#d9c9fb", "#9c5f3d", "#4ba9b3", "#a6617c"], folder_id: '4', id: 1}```|
 | 'api/v1/folders/:folderId| **PUT/PATCH** | **pending** |
 | 'api/v1/folders/:folderId/palettes/:paletteId'| **PUT/PATCH** | **pending** |
 | 'api/v1/folders/:folderId      | **DELETE**      | **A text response** Ex: ```'Folder has been deleted'``` |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ BackEnd Repo for Palette Picker
 | 'api/v1/folders/:folderId/palettes/:paletteId'| **GET**| **A single palette (object)** Ex: ```{"id": 1, "palette_name": "Palette #1", "color_one": "#80adaa", "color_two": "#d9c9fb", "color_three": "#9c5f3d", "color_four": "#4ba9b3", "color_five": "#a6617c", "folder_id": 1}```|
 | 'api/v1/folders'| **POST**  *Must include folder_name(string) in body of request object Ex:* ```{folder_name:'Palettes to Save the World'}```|id of posted folder: ```{id: <integer}```|
 | 'api/v1/folders/:folderId/palettes'          | **POST** *Must include paletteName(string) and colors(Array of strings) in body of request object Ex:* ```{paletteName: 'Big Ole Palette', colors: ["#80adaa", "#d9c9fb", "#9c5f3d", "#4ba9b3", "#a6617c"]}```| **An object with newly created palette, folderId, and its paletteId Ex:**```{paletteName: 'Big Ole Palette', colors: ["#80adaa", "#d9c9fb", "#9c5f3d", "#4ba9b3", "#a6617c"], folder_id: '4', id: 1}```|
-| 'api/v1/folders/:folderId| **PUT/PATCH** | **pending** |
+| 'api/v1/folders/:folderId| **PATCH** *Must include { folderName: <String> }  in request body* | **An object with the updated name Ex:** ```{folderName: 'Wubbalubbadubdub'}```|
 | 'api/v1/folders/:folderId/palettes/:paletteId'| **PUT/PATCH** | **pending** |
 | 'api/v1/folders/:folderId      | **DELETE**      | **A text response** Ex: ```'Folder has been deleted'``` |
 | 'api/v1/folders/:folderId/palettes/:paletteId' | **DELETE** | **A text response** Ex: ```'Palette has been deleted'``` |

--- a/app.js
+++ b/app.js
@@ -128,7 +128,19 @@ app.patch('/api/v1/folders/:folderId', async (req, res) => {
   } catch(error) {
     res.status(500).json({ error })
   }
-})
+});
+
+app.delete('/api/v1/folders/:folderId', async (req, res) => {
+  const folderId = req.params.folderId
+
+  try {
+    await database('palettes').select().where('folder_id', folderId).del();
+    await database('folders').select().where('id', folderId).del();
+    res.status(200).send('Folder has been deleted');
+  } catch (error) {
+    res.status(500).json({ error });
+  }
+});
 
 app.get('/', (req, res) => {
   res.send('Welcome to the Palette Picker API');

--- a/app.js
+++ b/app.js
@@ -124,7 +124,7 @@ app.patch('/api/v1/folders/:folderId', async (req, res) => {
 
   try {
     await database('folders').where("id", folderId).update("folder_name", newFolderName.folderName)
-    return res.status(204).send('Folder name successfully updated')
+    return res.status(200).json(newFolderName)
   } catch(error) {
     res.status(500).json({ error })
   }

--- a/app.js
+++ b/app.js
@@ -63,6 +63,38 @@ app.get('/api/v1/folders/:folderId/palettes/:paletteId', async (req, res) => {
   } catch(error) {
     res.status(500).send({ error });
   }
+});
+
+app.post('/api/v1/folders/:folderId/palettes', async (req, res) => {
+  let palette = req.body;
+  const folderId = req.params.folderId;
+
+  Object.assign(palette, {folder_id: folderId})
+
+  for (let requiredParameter of ['paletteName', 'colors']) {
+    if (!palette[requiredParameter]) {
+      return res
+        .status(422)
+        .send({ error: `Expected format: { paletteName: <String>, colors: <Array of Strings>}. You're missing a "${requiredParameter}" property.` });
+    }
+  }
+
+  try {
+    const id = await database('palettes').insert({
+      palette_name: palette.paletteName,
+      color_one: palette.colors[0],
+      color_two: palette.colors[1],
+      color_three: palette.colors[2],
+      color_four: palette.colors[3],
+      color_five: palette.colors[4],
+      folder_id: palette.folder_id
+    }, 'id');
+    
+    Object.assign(palette, {id: id[0]})
+    res.status(201).json(palette)
+  } catch(error) {
+    res.status(500).json({ error });
+  }
 })
 
 app.post('/api/v1/folders', async (req, res) => {

--- a/app.js
+++ b/app.js
@@ -137,10 +137,21 @@ app.delete('/api/v1/folders/:folderId', async (req, res) => {
     await database('palettes').select().where('folder_id', folderId).del();
     await database('folders').select().where('id', folderId).del();
     res.status(200).send('Folder has been deleted');
-  } catch (error) {
+  } catch(error) {
     res.status(500).json({ error });
   }
 });
+
+app.delete('/api/v1/folders/:folderId/palettes/:paletteId', async (req, res) => {
+  const paletteId = req.params.paletteId;
+
+  try {
+    await database('palettes').select().where('id', paletteId).del();
+    res.status(200).send('Palette has been deleted');
+  } catch(error) {
+    res.status(500).json({ error });
+  }
+})
 
 app.get('/', (req, res) => {
   res.send('Welcome to the Palette Picker API');

--- a/app.js
+++ b/app.js
@@ -111,6 +111,23 @@ app.post('/api/v1/folders', async (req, res) => {
   } catch(error) {
     res.status(500).json({ error })
   }
+});
+
+app.patch('/api/v1/folders/:folderId', async (req, res) => {
+  const newFolderName = req.body;
+  const folderId = req.params.folderId;
+
+  if (!newFolderName.folderName) {
+    return res.status(422)
+    .json({ error: 'Expected format: {folderName: <String>}' })
+  }
+
+  try {
+    await database('folders').where("id", folderId).update("folder_name", newFolderName.folderName)
+    return res.status(204).send('Folder name successfully updated')
+  } catch(error) {
+    res.status(500).json({ error })
+  }
 })
 
 app.get('/', (req, res) => {

--- a/app.test.js
+++ b/app.test.js
@@ -161,15 +161,17 @@ describe('App', () => {
     });
   });
   describe('PATCH "api/v1/folders/:folderId', () => {
-    it('should return a status code 204 and update the folders name', async () => {
+    it('should return a status code 200 and the updated folders name', async () => {
       const folder = await database('folders').first();
       const folderId = folder.id;
 
       const patchFolder = { folderName: 'New Palette Name' };
 
       const res = await request(app).patch(`/api/v1/folders/${folderId}`).send(patchFolder);
-      console.log(res)
-      expect(res.status).toBe(204);
+
+      
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(patchFolder);
     })
   })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -194,6 +194,6 @@ describe('App', () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toEqual('Folder has been deleted');
-    })
-  })
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -186,7 +186,7 @@ describe('App', () => {
     });
   });
   describe('DELETE "/api/v1/folders/:folderId', () => {
-    it('should return a status code 204 and message that folder has been deleted', async () => {
+    it('should return a status code 200 and message that folder has been deleted', async () => {
       const folder = await database('folders').first();
       const folderId = folder.id;
 
@@ -194,6 +194,17 @@ describe('App', () => {
 
       expect(res.status).toBe(200);
       expect(res.text).toEqual('Folder has been deleted');
+    });
+  });
+  describe('DELETE "/api/v1/folders/:folderId/palettes/:paletteId', () => {
+    it('should return a status code 200 and message that palette has been deleted', async () => {
+      const palette = await database('palettes').first();
+      const paletteId = palette.id;
+
+      const res = await request(app).delete(`/api/v1/folders/${folderId}`)
+
+      expect(res.status).toBe(200);
+      expect(res.text).toEqual('Palette has been deleted');
     });
   });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -120,7 +120,7 @@ describe('App', () => {
   });
 
   describe('POST /api/v1/folders', () => {
-    it('should responde with 201 after posting a new folder', async () => {
+    it('should respond with 201 after posting a new folder', async () => {
       const newFolder = {folder_name: 'Colors to Save the World'};
 
       const res = await request(app).post('/api/v1/folders').send(newFolder);
@@ -134,7 +134,7 @@ describe('App', () => {
     });
   });
 
-  describe('POST "api/v1/folders/:folderId/palettes"', () => {
+  describe('POST "/api/v1/folders/:folderId/palettes"', () => {
     it('should return a 201 status code and the newly created palette', async () => {
       const folder = await database('folders').first()
       const folderId = folder.id
@@ -160,7 +160,7 @@ describe('App', () => {
       expect(JSON.parse(res.text)).toEqual({ error: `Expected format: { paletteName: <String>, colors: <Array of Strings>}. You're missing a "colors" property.` })
     });
   });
-  describe('PATCH "api/v1/folders/:folderId', () => {
+  describe('PATCH "/api/v1/folders/:folderId', () => {
     it('should return a status code 200 and the updated folders name', async () => {
       const folder = await database('folders').first();
       const folderId = folder.id;
@@ -178,11 +178,22 @@ describe('App', () => {
       const folderId = folder.id;
 
       const patchError = { whoops: 'This wont work' };
-      
+
       const res = await request(app).patch(`/api/v1/folders/${folderId}`).send(patchError);
 
       expect(res.status).toBe(422);
       expect(JSON.parse(res.text)).toEqual({ error: 'Expected format: {folderName: <String>}' });
+    });
+  });
+  describe('DELETE "/api/v1/folders/:folderId', () => {
+    it('should return a status code 204 and message that folder has been deleted', async () => {
+      const folder = await database('folders').first();
+      const folderId = folder.id;
+
+      const res = await request(app).delete(`/api/v1/folders/${folderId}`)
+
+      expect(res.status).toBe(200);
+      expect(res.text).toEqual('Folder has been deleted');
     })
   })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -131,8 +131,8 @@ describe('App', () => {
 
       expect(res.status).toBe(201);
       expect(folder.folder_name).toEqual(newFolder.folder_name)
-    })
-  })
+    });
+  });
 
   describe('POST "api/v1/folders/:folderId/palettes"', () => {
     it('should return a 201 status code and the newly created palette', async () => {
@@ -158,6 +158,6 @@ describe('App', () => {
 
       expect(res.status).toBe(422);
       expect(JSON.parse(res.text)).toEqual({ error: `Expected format: { paletteName: <String>, colors: <Array of Strings>}. You're missing a "colors" property.` })
-    })
-  })
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -148,5 +148,16 @@ describe('App', () => {
       expect(res.status).toBe(201);
       expect(palette.palette_name).toEqual(newPalette.paletteName);
     });
+
+    it('should return a 422 status code and an error message informing missing parameters', async () => {
+      const folder = await database('folders').first();
+      const folderId = folder.id;
+      const errorPalette = { paletteName: 'There is a snake in my boot' };
+
+      const res = await request(app).post(`/api/v1/folders/${folderId}/palettes`).send(errorPalette);
+
+      expect(res.status).toBe(422);
+      expect(JSON.parse(res.text)).toEqual({ error: `Expected format: { paletteName: <String>, colors: <Array of Strings>}. You're missing a "colors" property.` })
+    })
   })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -133,5 +133,20 @@ describe('App', () => {
       expect(folder.folder_name).toEqual(newFolder.folder_name)
     })
   })
-});
 
+  describe('POST "api/v1/folders/:folderId/palettes"', () => {
+    it('should return a 201 status code and the newly created palette', async () => {
+      const folder = await database('folders').first()
+      const folderId = folder.id
+      const newPalette = { paletteName: 'Test Palette #1', colors: ['#80e56a', '#51c5c5', '#51ed3d', '#7f6851', '#826fb0']};
+
+      const res = await request(app).post(`/api/v1/folders/${folderId}/palettes`).send(newPalette);
+      
+      const palettes = await database('palettes').select().where('id', res.body.id);
+      const palette = palettes[0];
+
+      expect(res.status).toBe(201);
+      expect(palette.palette_name).toEqual(newPalette.paletteName);
+    });
+  })
+});

--- a/app.test.js
+++ b/app.test.js
@@ -172,6 +172,17 @@ describe('App', () => {
       
       expect(res.status).toBe(200);
       expect(res.body).toEqual(patchFolder);
+    });
+    it('should return a status code 422 and an error message informing missing parameters', async () => {
+      const folder = await database('folders').first();
+      const folderId = folder.id;
+
+      const patchError = { whoops: 'This wont work' };
+      
+      const res = await request(app).patch(`/api/v1/folders/${folderId}`).send(patchError);
+
+      expect(res.status).toBe(422);
+      expect(JSON.parse(res.text)).toEqual({ error: 'Expected format: {folderName: <String>}' });
     })
   })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -200,8 +200,9 @@ describe('App', () => {
     it('should return a status code 200 and message that palette has been deleted', async () => {
       const palette = await database('palettes').first();
       const paletteId = palette.id;
+      const folderId = palette.folder_id
 
-      const res = await request(app).delete(`/api/v1/folders/${folderId}`)
+      const res = await request(app).delete(`/api/v1/folders/${folderId}/palettes/${paletteId}`)
 
       expect(res.status).toBe(200);
       expect(res.text).toEqual('Palette has been deleted');

--- a/app.test.js
+++ b/app.test.js
@@ -160,4 +160,16 @@ describe('App', () => {
       expect(JSON.parse(res.text)).toEqual({ error: `Expected format: { paletteName: <String>, colors: <Array of Strings>}. You're missing a "colors" property.` })
     });
   });
+  describe('PATCH "api/v1/folders/:folderId', () => {
+    it('should return a status code 204 and update the folders name', async () => {
+      const folder = await database('folders').first();
+      const folderId = folder.id;
+
+      const patchFolder = { folderName: 'New Palette Name' };
+
+      const res = await request(app).patch(`/api/v1/folders/${folderId}`).send(patchFolder);
+      console.log(res)
+      expect(res.status).toBe(204);
+    })
+  })
 });


### PR DESCRIPTION
### What does this PR do?

This PR adds functionality and testing to the DELETE route handler for the '/api/v1/folders/:folderId/palettes/:paletteId' endpoint

### Where should the reviewer start? 

A reviewer should start by examining the app.js and app.test.js files and reviewing how the delete method is working for this endpoint, and ensure that all paths (that are able to be tested) are covered by tests.

### Can this be manually tested? 

Yes, a reviewer can run npm run test to see the passing tests. Or they can run npm run start and utilize Postman to destroy an existing palette from the database.

Resolves #26 